### PR TITLE
update CUDA install links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This action installs the [NVIDIA® CUDA® Toolkit](https://developer.nvidia.com/
 
 **Optional** The CUDA version to install. View `src/link/windows-links.ts` and `src/link/linux-links.ts` for available versions.
 
-Default: `'13.2.0'`.
+Default: `'13.2.1'`.
 
 ### `sub-packages`
 
@@ -88,10 +88,10 @@ The path where cuda is installed (same as `CUDA_PATH` in `GITHUB_ENV`).
 
 ```yaml
 steps:
-- uses: N-Storm/cuda-toolkit@v0.2.33
+- uses: N-Storm/cuda-toolkit@v0.2.34
   id: cuda-toolkit
   with:
-    cuda: '13.2.0'
+    cuda: '13.2.1'
 
 - run: echo "Installed cuda version is: ${{steps.cuda-toolkit.outputs.cuda}}"
 

--- a/src/links/linux-links.ts
+++ b/src/links/linux-links.ts
@@ -15,8 +15,16 @@ export class LinuxLinks extends AbstractLinks {
     // Map of cuda SemVer version to download URL
     this.cudaVersionToURL = new Map([
       [
+        '13.2.1',
+        'https://developer.download.nvidia.com/compute/cuda/13.2.1/local_installers/cuda_13.2.1_595.58.03_linux.run'
+      ],
+      [
         '13.2.0',
         'https://developer.download.nvidia.com/compute/cuda/13.2.0/local_installers/cuda_13.2.0_595.45.04_linux.run'
+      ],
+      [
+        '13.1.2',
+        'https://developer.download.nvidia.com/compute/cuda/13.1.2/local_installers/cuda_13.1.2_590.48.01_linux.run'
       ],
       [
         '13.1.1',
@@ -25,6 +33,10 @@ export class LinuxLinks extends AbstractLinks {
       [
         '13.1.0',
         'https://developer.download.nvidia.com/compute/cuda/13.1.0/local_installers/cuda_13.1.0_590.44.01_linux.run'
+      ],
+      [
+        '13.0.3',
+        'https://developer.download.nvidia.com/compute/cuda/13.0.3/local_installers/cuda_13.0.3_580.126.20_linux.run'
       ],
       [
         '13.0.2',
@@ -45,6 +57,10 @@ export class LinuxLinks extends AbstractLinks {
       [
         '12.9.0',
         'https://developer.download.nvidia.com/compute/cuda/12.9.0/local_installers/cuda_12.9.0_575.51.03_linux.run'
+      ],
+      [
+        '12.8.2',
+        'https://developer.download.nvidia.com/compute/cuda/12.8.2/local_installers/cuda_12.8.2_570.211.01_linux.run'
       ],
       [
         '12.8.1',

--- a/src/links/linux-links.ts
+++ b/src/links/linux-links.ts
@@ -51,6 +51,10 @@ export class LinuxLinks extends AbstractLinks {
         'https://developer.download.nvidia.com/compute/cuda/13.0.0/local_installers/cuda_13.0.0_580.65.06_linux.run'
       ],
       [
+        '12.9.2',
+        'https://developer.download.nvidia.com/compute/cuda/12.9.2/local_installers/cuda_12.9.2_575.57.08_linux.run'
+      ],
+      [
         '12.9.1',
         'https://developer.download.nvidia.com/compute/cuda/12.9.1/local_installers/cuda_12.9.1_575.57.08_linux.run'
       ],

--- a/src/links/windows-links.ts
+++ b/src/links/windows-links.ts
@@ -25,8 +25,16 @@ export class WindowsLinks extends AbstractLinks {
 
   private cudaVersionToNetworkUrl: Map<string, string> = new Map([
     [
+      '13.2.1',
+      'https://developer.download.nvidia.com/compute/cuda/13.2.1/network_installers/cuda_13.2.1_windows_network.exe'
+    ],
+    [
       '13.2.0',
       'https://developer.download.nvidia.com/compute/cuda/13.2.0/network_installers/cuda_13.2.0_windows_network.exe'
+    ],
+    [
+      '13.1.2',
+      'https://developer.download.nvidia.com/compute/cuda/13.1.2/network_installers/cuda_13.1.2_windows_network.exe'
     ],
     [
       '13.1.1',
@@ -35,6 +43,10 @@ export class WindowsLinks extends AbstractLinks {
     [
       '13.1.0',
       'https://developer.download.nvidia.com/compute/cuda/13.1.0/network_installers/cuda_13.1.0_windows_network.exe'
+    ],
+    [
+      '13.0.3',
+      'https://developer.download.nvidia.com/compute/cuda/13.0.3/network_installers/cuda_13.0.3_windows_network.exe'
     ],
     [
       '13.0.2',
@@ -55,6 +67,10 @@ export class WindowsLinks extends AbstractLinks {
     [
       '12.9.0',
       'https://developer.download.nvidia.com/compute/cuda/12.9.0/network_installers/cuda_12.9.0_windows_network.exe'
+    ],
+    [
+      '12.8.2',
+      'https://developer.download.nvidia.com/compute/cuda/12.8.2/network_installers/cuda_12.8.2_windows_network.exe'
     ],
     [
       '12.8.1',

--- a/src/links/windows-links.ts
+++ b/src/links/windows-links.ts
@@ -61,6 +61,10 @@ export class WindowsLinks extends AbstractLinks {
       'https://developer.download.nvidia.com/compute/cuda/13.0.0/network_installers/cuda_13.0.0_windows_network.exe'
     ],
     [
+      '12.9.2',
+      'https://developer.download.nvidia.com/compute/cuda/12.9.2/network_installers/cuda_12.9.2_windows_x86_64_network.exe'
+    ],
+    [
       '12.9.1',
       'https://developer.download.nvidia.com/compute/cuda/12.9.1/network_installers/cuda_12.9.1_windows_network.exe'
     ],


### PR DESCRIPTION
Added Linux and Windows install links for CUDA 13.2.1, 13.1.2, 13.0.3, and 12.8.2. also updated the version number and changed the default to 13.2.1.